### PR TITLE
ajax模块android和ios版同时增加application/json格式请求头支持

### DIFF
--- a/plugins/android/eeui/src/main/java/app/eeui/framework/extend/module/eeuiAjax.java
+++ b/plugins/android/eeui/src/main/java/app/eeui/framework/extend/module/eeuiAjax.java
@@ -33,6 +33,7 @@ public class eeuiAjax {
         JSONObject headers = eeuiJson.parseObject(json.getString("headers"));
         JSONObject data = eeuiJson.parseObject(json.getString("data"));
         JSONObject files = eeuiJson.parseObject(json.getString("files"));
+        boolean isJson = false;
         //
         if (name.isEmpty()) {
             if (context instanceof PageActivity) {
@@ -49,9 +50,13 @@ public class eeuiAjax {
         if (headers.size() > 0) {
             for (Map.Entry<String, Object> entry : headers.entrySet()) {
                 mData.put("header:" + entry.getKey(), entry.getValue());
+                if("Content-Type".equals(entry.getKey()) && "application/json".equals(entry.getValue().toString())) {
+                    mData.put("datas:" + entry.getKey(), data);
+                    isJson = true;
+                }
             }
         }
-        if (data.size() > 0) {
+        if (data.size() > 0 && !isJson) {
             for (Map.Entry<String, Object> entry : data.entrySet()) {
                 mData.put(entry.getKey(), entry.getValue());
             }

--- a/plugins/android/eeui/src/main/java/app/eeui/framework/extend/module/eeuiIhttp.java
+++ b/plugins/android/eeui/src/main/java/app/eeui/framework/extend/module/eeuiIhttp.java
@@ -87,6 +87,9 @@ public class eeuiIhttp {
                     }else if (eeuiCommon.leftExists(key.toLowerCase(), "header:")) {
                         key = key.substring(7).trim();
                         params.addHeader(key, String.valueOf(value));
+                    }else if (eeuiCommon.leftExists(key.toLowerCase(), "datas:")) {
+                        params.setAsJsonContent(true);
+                        params.setBodyContent(value.toString());
                     }else if (eeuiCommon.leftExists(key.toLowerCase(), "file:")) {
                         key = key.substring(5).trim();
                         if (value instanceof JSONArray) {

--- a/plugins/ios/eeui/eeui/Moduld/eeuiAjaxManager.m
+++ b/plugins/ios/eeui/eeui/Moduld/eeuiAjaxManager.m
@@ -72,6 +72,10 @@
     //设置请求头
     for (NSString *key  in headers.allKeys) {
         NSString *value = [NSString stringWithFormat:@"%@", headers[key]];
+        if([value isEqualToString:@"application/json"]) {
+            //设置请求体数据为json类型
+            manager.requestSerializer = [AFJSONRequestSerializer serializer];
+        }
         [manager.requestSerializer setValue:value forHTTPHeaderField:key];
     }
 


### PR DESCRIPTION
ajax模块android和ios版同时增加application/json格式请求头支持
如果不配置eeui.ajax的headers属性，默认请求头格式不变仍为（application/x-www-form-urlencoded）
如果配置属性 headers: {
            "Content-Type": "application/json"
          }
则请求头的Content-type变为application/json格式