### PR TITLE
iOS：支持读取本地 Assets 图片

### DIFF
--- a/plugins/eeui/WeexSDK/ios/ios/sdk/WeexSDK/Sources/Component/WXImageComponent.m
+++ b/plugins/eeui/WeexSDK/ios/ios/sdk/WeexSDK/Sources/Component/WXImageComponent.m
@@ -578,8 +578,12 @@ WX_EXPORT_METHOD(@selector(save:))
     
     WXLogDebug(@"Updating image:%@, component:%@", self.imageSrc, self.ref);
     NSDictionary *userInfo = @{@"imageQuality":@(self.imageQuality), @"imageSharp":@(self.imageSharp), @"blurRadius":@(self.blurRadius), @"instanceId":[self _safeInstanceId], @"pageURL": self.weexInstance.scriptURL ?: @""};
-    NSString * newURL = [imageSrc copy];
-    WX_REWRITE_URL(imageSrc, WXResourceTypeImage, self.weexInstance)
+
+    NSString * newURL = imageSrc;
+    if (![imageSrc hasPrefix: @"local:///"]) {
+        NSString * newURL = [imageSrc copy];
+        WX_REWRITE_URL(imageSrc, WXResourceTypeImage, self.weexInstance)
+    }
     __weak typeof(self) weakSelf = self;
     //eeui dev
     dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
iOS：支持读取本地 Assets 图片
image 的 src 形如 local:///<resId>，resId = Assets 中的资源名

（Android 已默认支持此格式，读取的是 drawable下的资源）