### PR TITLE
iOS：支持读取本地 Assets 图片, image 的 src 形如 local:///<resId>

### DIFF
--- a/platforms/ios/eeuiApp/eeuiApp/Info.plist
+++ b/platforms/ios/eeuiApp/eeuiApp/Info.plist
@@ -117,6 +117,6 @@
 	<key>UIUserInterfaceStyle</key>
 	<string>Light</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
+	<true/>
 </dict>
 </plist>

--- a/plugins/eeui/WeexSDK/ios/ios/sdk/WeexSDK/Sources/Component/WXImageComponent.m
+++ b/plugins/eeui/WeexSDK/ios/ios/sdk/WeexSDK/Sources/Component/WXImageComponent.m
@@ -578,8 +578,12 @@ WX_EXPORT_METHOD(@selector(save:))
     
     WXLogDebug(@"Updating image:%@, component:%@", self.imageSrc, self.ref);
     NSDictionary *userInfo = @{@"imageQuality":@(self.imageQuality), @"imageSharp":@(self.imageSharp), @"blurRadius":@(self.blurRadius), @"instanceId":[self _safeInstanceId], @"pageURL": self.weexInstance.scriptURL ?: @""};
-    NSString * newURL = [imageSrc copy];
-    WX_REWRITE_URL(imageSrc, WXResourceTypeImage, self.weexInstance)
+    
+    NSString * newURL = imageSrc;
+    if (![imageSrc hasPrefix: @"local:///"]) {
+        NSString * newURL = [imageSrc copy];
+        WX_REWRITE_URL(imageSrc, WXResourceTypeImage, self.weexInstance)
+    }
     __weak typeof(self) weakSelf = self;
     //eeui dev
     dispatch_async(dispatch_get_main_queue(), ^{

--- a/plugins/eeui/WeexSDK/ios/ios/sdk/WeexSDK/Sources/Component/WXImageComponent.m
+++ b/plugins/eeui/WeexSDK/ios/ios/sdk/WeexSDK/Sources/Component/WXImageComponent.m
@@ -581,7 +581,7 @@ WX_EXPORT_METHOD(@selector(save:))
     
     NSString * newURL = imageSrc;
     if (![imageSrc hasPrefix: @"local:///"]) {
-        NSString * newURL = [imageSrc copy];
+        newURL = [imageSrc copy];
         WX_REWRITE_URL(imageSrc, WXResourceTypeImage, self.weexInstance)
     }
     __weak typeof(self) weakSelf = self;

--- a/plugins/eeui/framework/ios/eeui/Handler/WXImgLoaderDefaultImpl.m
+++ b/plugins/eeui/framework/ios/eeui/Handler/WXImgLoaderDefaultImpl.m
@@ -38,6 +38,16 @@
 #define WXDispatchQueueSetterSementics assign
 #endif
 
+@interface EeuiAssetsLoaderOperation : NSObject<WXImageOperationProtocol>
+
+@end
+
+@implementation EeuiAssetsLoaderOperation
+
+- (void)cancel {}
+
+@end
+
 @interface WXImgLoaderDefaultImpl()
 
 @property (WXDispatchQueueSetterSementics, nonatomic) dispatch_queue_t ioQueue;
@@ -48,6 +58,13 @@
 
 - (id<WXImageOperationProtocol>)downloadImageWithURL:(NSString *)url imageFrame:(CGRect)imageFrame userInfo:(NSDictionary *)userInfo completed:(void(^)(UIImage *image,  NSError *error, BOOL finished))completedBlock
 {
+    if ([url hasPrefix: @"local:///"]) {
+        UIImage *img = [UIImage imageNamed: [url substringFromIndex: @"local:///".length]];
+        completedBlock(img, nil, YES);
+        
+        return [EeuiAssetsLoaderOperation new];
+    }
+    
     WXSDKInstance *instance = [WXSDKManager instanceForID:userInfo[@"instanceId"]];
     url = [Config verifyFile:[DeviceUtil rewriteUrl:[self handCachePageUr:url] mInstance:instance]];
     url = [DeviceUtil urlEncoder:url];

--- a/plugins/eeui/framework/ios/eeui/eeuiViewController.m
+++ b/plugins/eeui/framework/ios/eeui/eeuiViewController.m
@@ -305,6 +305,15 @@ static int easyNavigationButtonTag = 8000;
     [CustomWeexSDKManager setKeyBoardlsVisible:_keyBoardlsVisible];
 }
 
+// iOS 13
+- (UIStatusBarStyle)preferredStatusBarStyle {
+    if ([_statusBarStyleCustom isEqualToString:@"1"]) {
+        return UIStatusBarStyleLightContent;
+    }else{
+        return UIStatusBarStyleDefault;
+    }
+}
+
 #pragma mark 生命周期
 - (void)lifeCycleEvent:(LifeCycleType)type
 {


### PR DESCRIPTION
iOS：支持读取本地 Assets 图片, image 的 src 形如 local:///<resId>，resId = Assets 中的资源名（Android 已默认支持此格式，读取的是 drawable下的资源）