### PR TITLE
修复webview注入后调用无参数方法，找不到方法问题

### DIFF
--- a/plugins/eeui/framework/android/src/main/java/app/eeui/framework/extend/view/webviewBridge/JsCallJava.java
+++ b/plugins/eeui/framework/android/src/main/java/app/eeui/framework/extend/view/webviewBridge/JsCallJava.java
@@ -111,7 +111,7 @@ public class JsCallJava {
                 Object[] values = new Object[0];
 
                 for (String key : mMethodsMap.keySet()) {
-                    if (key.startsWith(methodName + "_")) {
+                    if (key.startsWith(methodName + "_") || (len==0 && key.equals(methodName))) {
 
                         sign = new StringBuilder(key);
                         currMethod = mMethodsMap.get(sign.toString());


### PR DESCRIPTION
今天在安卓下，使用webview组件打开网页，网页里通过
`
let eeui = requireModuleJs("eeui");
eeui.clearAllVariate();
`
调用后无反应，通过debug，得出是因为该方法无参数，导致 genJavaMethodSign 方法处理时，没有附带下划线；
而在匹配时使用下划线匹配，所以出现找不到该方法