### PR TITLE
使用Tabbar控件，沉浸式，需要子页面的状态栏文字颜色不一样，切换tabbar页面时候改变状态栏的文字颜色会导致页面下移

### DIFF
--- a/plugins/eeui/framework/android/src/main/res/layout/layout_eeui_tabbar_page.xml
+++ b/plugins/eeui/framework/android/src/main/res/layout/layout_eeui_tabbar_page.xml
@@ -2,8 +2,7 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:fitsSystemWindows="true">
+    android:layout_height="match_parent">
 
     <!-- weex -->
     <View


### PR DESCRIPTION
fix：问题描述：使用Tabbar控件，沉浸式，需要子页面的状态栏文字颜色不一样，切换tabbar页面时候改变状态栏的文字颜色，安卓代码中由于子页面布局使用了fitsSystemWindows为true，导致这种改变状态栏文字颜色，系统会设置tab page页面的padding top值为状态栏高度，会出现页面下移。故需要取消设置fitsSystemWindows，默认使用false；