### PR TITLE
新增：原生导航栏标题与左右item可设置titleBold为true改变文字为粗体； 修复：调试模式下，eeuiTabbarCompone…

### DIFF
--- a/plugins/eeui/framework/android/src/main/java/app/eeui/framework/activity/PageActivity.java
+++ b/plugins/eeui/framework/android/src/main/java/app/eeui/framework/activity/PageActivity.java
@@ -1480,6 +1480,7 @@ public class PageActivity extends AppCompatActivity {
         String title = eeuiJson.getString(item, "title", "");
         String titleColor = eeuiJson.getString(item, "titleColor", "");
         float titleSize = eeuiJson.getFloat(item, "titleSize", 32f);
+        boolean titleBold = eeuiJson.getBoolean(item, "titleBold", false);
         String subtitle = eeuiJson.getString(item, "subtitle", "");
         String subtitleColor = eeuiJson.getString(item, "subtitleColor", "");
         float subtitleSize = eeuiJson.getFloat(item, "subtitleSize", 24f);
@@ -1501,6 +1502,7 @@ public class PageActivity extends AppCompatActivity {
             titleBarTitle.setVisibility(View.VISIBLE);
             titleBarTitle.setText(title);
             titleBarTitle.setTextSize(TypedValue.COMPLEX_UNIT_PX, eeuiScreenUtils.weexPx2dp(mWXSDKInstance, titleSize));
+            titleBarTitle.getPaint().setFakeBoldText(titleBold);
             titleBarTitle.setTextColor(Color.parseColor(titleColor));
         }
 
@@ -1555,6 +1557,7 @@ public class PageActivity extends AppCompatActivity {
             String title = eeuiJson.getString(item, "title", "");
             String titleColor = eeuiJson.getString(item, "titleColor", "");
             float titleSize = eeuiJson.getFloat(item, "titleSize", 28f);
+            boolean titleBold = eeuiJson.getBoolean(item, "titleBold", false);
             String icon = eeuiJson.getString(item, "icon", "");
             String iconColor = eeuiJson.getString(item, "iconColor", "");
             float iconSize = eeuiJson.getFloat(item, "iconSize", 28f);
@@ -1608,6 +1611,7 @@ public class PageActivity extends AppCompatActivity {
                 titleView.setGravity(Gravity.CENTER);
                 titleView.setText(title);
                 titleView.setTextSize(TypedValue.COMPLEX_UNIT_PX, eeuiScreenUtils.weexPx2dp(mWXSDKInstance, titleSize));
+                titleView.getPaint().setFakeBoldText(titleBold);
                 titleView.setTextColor(Color.parseColor(titleColor));
                 customButton.addView(titleView);
             }

--- a/plugins/eeui/framework/ios/eeui/Component/eeuiRippleComponent.m
+++ b/plugins/eeui/framework/ios/eeui/Component/eeuiRippleComponent.m
@@ -74,14 +74,14 @@
 {
     CGRect frame = self.view.frame;
     if (_rippleButton == nil) {
-        __block typeof(self) bself = self;
+        __weak __typeof(self)weakSelf = self;
         _rippleButton = [[ZYCRippleButton alloc]initWithFrame:CGRectMake(0, 0, frame.size.width, frame.size.height)];
         _rippleButton.rippleLineWidth = 1;
         _rippleButton.rippleColor = [UIColor darkGrayColor];
         _rippleButton.backgroundColor = [UIColor clearColor];
         _rippleButton.rippleBlock = ^(void){
-            [bself fireEvent:@"click" params:nil];
-            [bself fireEvent:@"itemClick" params:nil];
+            [weakSelf fireEvent:@"click" params:nil];
+            [weakSelf fireEvent:@"itemClick" params:nil];
         };
         [self.view addSubview:_rippleButton];
     }else{

--- a/plugins/eeui/framework/ios/eeui/Component/eeuiTabbarComponent.m
+++ b/plugins/eeui/framework/ios/eeui/Component/eeuiTabbarComponent.m
@@ -858,7 +858,7 @@ WX_EXPORT_METHOD(@selector(setTabSlideSwitch:))
                 [eeuiNewPageManager removeTabViewDebug:tempName];
             }
         };
-
+        __weak __typeof(vc)weakVC = vc;
         [eeuiNewPageManager setTabViewDebug:tempName callback:^(id result, BOOL keepAlive) {
             NSString *url = [WXConvert NSString:result];
             if ([[DeviceUtil realUrl:[vc url]] hasPrefix:url]) {

--- a/plugins/eeui/framework/ios/eeui/Module/eeuiNewPageManager.m
+++ b/plugins/eeui/framework/ios/eeui/Module/eeuiNewPageManager.m
@@ -597,7 +597,8 @@
 - (void)setPageData:(NSString*)pageName vc:(eeuiViewController *)vc
 {
     if (pageName.length > 0) {
-        [self.viewData setObject:vc forKey:pageName];
+        __weak __typeof(vc)weakVC = vc;
+        [self.viewData setObject:weakVC forKey:pageName];
 
         NSMutableDictionary *res = [NSMutableDictionary dictionaryWithDictionary:@{}];
         [res setObject:vc.url forKey:@"url"];

--- a/plugins/eeui/framework/ios/eeui/eeuiViewController.m
+++ b/plugins/eeui/framework/ios/eeui/eeuiViewController.m
@@ -1154,6 +1154,7 @@ static int easyNavigationButtonTag = 8000;
     NSString *title = item[@"title"] ? [WXConvert NSString:item[@"title"]] : @"";
     NSString *titleColor = item[@"titleColor"] ? [WXConvert NSString:item[@"titleColor"]] : @"";
     CGFloat titleSize = item[@"titleSize"] ? [WXConvert CGFloat:item[@"titleSize"]] : 32.0;
+    BOOL titleBold = [item[@"titleBold"] boolValue];
     NSString *subtitle = item[@"subtitle"] ? [WXConvert NSString:item[@"subtitle"]] : @"";
     NSString *subtitleColor = item[@"subtitleColor"] ? [WXConvert NSString:item[@"subtitleColor"]] : @"";
     CGFloat subtitleSize = item[@"subtitleSize"] ? [WXConvert CGFloat:item[@"subtitleSize"]] : 24.0;
@@ -1178,7 +1179,12 @@ static int easyNavigationButtonTag = 8000;
     [titleLabel setBackgroundColor:[UIColor clearColor]];
     [titleLabel setTextColor:[WXConvert UIColor:titleColor]];
     [titleLabel setText:[[NSString alloc] initWithFormat:@"  %@  ", title]];
-    [titleLabel setFont:[UIFont systemFontOfSize:[self NAVSCALE:titleSize]]];
+    if (titleBold) {
+        [titleLabel setFont:[UIFont boldSystemFontOfSize:[self NAVSCALE:titleSize]]];
+    } else {
+        [titleLabel setFont:[UIFont systemFontOfSize:[self NAVSCALE:titleSize]]];
+    }
+    
     [titleLabel sizeToFit];
 
     if (subtitle.length > 0) {
@@ -1252,6 +1258,7 @@ static int easyNavigationButtonTag = 8000;
         NSString *title = item[@"title"] ? [WXConvert NSString:item[@"title"]] : @"";
         NSString *titleColor = item[@"titleColor"] ? [WXConvert NSString:item[@"titleColor"]] : @"";
         CGFloat titleSize = item[@"titleSize"] ? [WXConvert CGFloat:item[@"titleSize"]] : 28.0;
+        BOOL titleBold = [item[@"titleBold"] boolValue];
         NSString *icon = item[@"icon"] ? [WXConvert NSString:item[@"icon"]] : @"";
         NSString *iconColor = item[@"iconColor"] ? [WXConvert NSString:item[@"iconColor"]] : @"";
         CGFloat iconSize = item[@"iconSize"] ? [WXConvert CGFloat:item[@"iconSize"]] : 28.0;
@@ -1282,7 +1289,12 @@ static int easyNavigationButtonTag = 8000;
             }
         }
         if (title.length > 0){
-            customButton.titleLabel.font = [UIFont systemFontOfSize:[self NAVSCALE:titleSize]];
+            if (titleBold) {
+                customButton.titleLabel.font = [UIFont boldSystemFontOfSize:[self NAVSCALE:titleSize]];
+            } else {
+                customButton.titleLabel.font = [UIFont systemFontOfSize:[self NAVSCALE:titleSize]];
+            }
+            
             [customButton setTitle:title forState:UIControlStateNormal];
             [customButton setTitleColor:[WXConvert UIColor:titleColor] forState:UIControlStateNormal];
             [customButton.titleLabel sizeToFit];


### PR DESCRIPTION
新增：原生导航栏标题与左右item可设置titleBold为true改变文字为粗体；
 修复：调试模式下，eeuiTabbarComponent 循环引用，导致tabbar下的所有子页面无法销毁问题； 
修复：eeuiRippleComponent  循环引用, 导致内存泄漏； 
修复：eeuiNewPageManager 中 viewData 属性强引用Controller, 导致Controller无法销毁问题；