### PR TITLE
修复：全局配置没用navigationBarStyle导致安卓崩溃的bug；修复：iOS导航栏加载icon的网络加载策略问题；

### DIFF
--- a/plugins/eeui/framework/android/src/main/java/app/eeui/framework/activity/PageActivity.java
+++ b/plugins/eeui/framework/android/src/main/java/app/eeui/framework/activity/PageActivity.java
@@ -1536,7 +1536,11 @@ public class PageActivity extends AppCompatActivity {
         });
 
         if (!mPageInfo.isFirstPage() && titleBarLeftNull) {
-            JSONObject styles = eeuiBase.config.getObject("navigationBarStyle").getJSONObject("left");
+            JSONObject defaultStyle = eeuiBase.config.getObject("navigationBarStyle");
+            JSONObject styles = new JSONObject();
+            if (defaultStyle != null && defaultStyle.getJSONObject("left") != null) {
+                styles = defaultStyle.getJSONObject("left");
+            }
             if (styles.get("icon") == null) {
                 styles.put("icon","tb-back");
             }

--- a/plugins/eeui/framework/ios/eeui/eeuiViewController.m
+++ b/plugins/eeui/framework/ios/eeui/eeuiViewController.m
@@ -1285,7 +1285,7 @@ static int easyNavigationButtonTag = 8000;
         if (icon.length > 0) {
             if (![self isFontIcon:icon]) {
                 icon = [DeviceUtil rewriteUrl:icon mInstance:[[WXSDKManager bridgeMgr] topInstance]];
-                [SDWebImageDownloader.sharedDownloader downloadImageWithURL:[NSURL URLWithString:icon] options:SDWebImageDownloaderLowPriority progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, BOOL finished) {
+                [SDWebImageDownloader.sharedDownloader downloadImageWithURL:[NSURL URLWithString:icon] options:SDWebImageDownloaderUseNSURLCache progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, BOOL finished) {
                     if (image) {
                         WXPerformBlockOnMainThread(^{
                             [customButton setImage:[DeviceUtil imageResize:image andResizeTo:CGSizeMake([self NAVSCALE:iconSize], [self NAVSCALE:iconSize]) icon:nil] forState:UIControlStateNormal];


### PR DESCRIPTION
修复：全局配置没用navigationBarStyle导致安卓崩溃的bug；
修复：iOS导航栏加载icon的网络加载策略问题，原策略为SDWebImageDownloaderLowPriority（下载优先级低，显示延迟高），改为SDWebImageDownloaderUseNSURLCache（系统缓存策略，低延迟） 