### PR TITLE
修复：iOS的image加载远端资源策略错误，导致加载同一资源不会缓存

### DIFF
--- a/plugins/eeui/framework/ios/eeui/Handler/WXImgLoaderDefaultImpl.m
+++ b/plugins/eeui/framework/ios/eeui/Handler/WXImgLoaderDefaultImpl.m
@@ -69,7 +69,7 @@
     url = [Config verifyFile:[DeviceUtil rewriteUrl:[self handCachePageUr:url] mInstance:instance]];
     url = [DeviceUtil urlEncoder:url];
     
-    return (id<WXImageOperationProtocol>)[SDWebImageDownloader.sharedDownloader downloadImageWithURL:[NSURL URLWithString:url] options:SDWebImageDownloaderLowPriority progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, BOOL finished) {
+    return (id<WXImageOperationProtocol>)[SDWebImageDownloader.sharedDownloader downloadImageWithURL:[NSURL URLWithString:url] options:SDWebImageDownloaderUseNSURLCache progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, BOOL finished) {
         if (completedBlock) {
             if (!image) {
                 image = [UIImage imageWithContentsOfFile:url];


### PR DESCRIPTION
修复：iOS的image加载远端资源策略错误，导致加载同一资源不会缓存